### PR TITLE
Remove /auth from URL path

### DIFF
--- a/bin/keycloak-httpd-client-install
+++ b/bin/keycloak-httpd-client-install
@@ -800,6 +800,7 @@ def main():
 
     group.add_argument('-s', '--keycloak-server-url',
                        required=True,
+                       type=utils.normalize_keycloak_server_url,
                        help='Keycloak server URL')
 
     group.add_argument('-a', '--keycloak-auth-role',

--- a/bin/keycloak-rest
+++ b/bin/keycloak-rest
@@ -177,7 +177,9 @@ def main():
 
     group.add_argument('-s', '--server',
                        required=True,
-                       help='DNS name or IP address of Keycloak server')
+                       help='URL pointing to Keycloak server. '
+                       'The URL should look like https://keycloak.example.com or '
+                       'for older version of keycloak https://keycloak.example.com/auth')
 
     group.add_argument('-a', '--auth-role',
                        choices=keycloak_rest.AUTH_ROLES,

--- a/bin/keycloak-rest
+++ b/bin/keycloak-rest
@@ -177,6 +177,7 @@ def main():
 
     group.add_argument('-s', '--server',
                        required=True,
+                       type=utils.normalize_keycloak_server_url,
                        help='URL pointing to Keycloak server. '
                        'The URL should look like https://keycloak.example.com or '
                        'for older version of keycloak https://keycloak.example.com/auth')

--- a/keycloak_httpd_client/keycloak_rest.py
+++ b/keycloak_httpd_client/keycloak_rest.py
@@ -14,36 +14,36 @@ ADMIN_CLIENT_ID = 'admin-cli'
 AUTH_ROLES = ['root-admin', 'realm-admin', 'anonymous']
 
 URL_OIDC_TOKEN = (
-    '{server}/auth/realms/{realm}/protocol/openid-connect/token')
+    '{server}/realms/{realm}/protocol/openid-connect/token')
 URL_SERVER_INFO = (
-    '{server}/auth/admin/serverinfo/')
+    '{server}/admin/serverinfo/')
 URL_REALMS = (
-    '{server}/auth/admin/realms')
+    '{server}/admin/realms')
 URL_REALMS_REALM = (
-    '{server}/auth/admin/realms/{realm}')
+    '{server}/admin/realms/{realm}')
 URL_REALM_SAML_DESCRIPTOR = (
-    '{server}/auth/realms/{realm}/protocol/saml/descriptor')
+    '{server}/realms/{realm}/protocol/saml/descriptor')
 
 URL_CLIENTS = (
-    '{server}/auth/admin/realms/{realm}/clients')
+    '{server}/admin/realms/{realm}/clients')
 URL_CLIENTS_ID = (
-    '{server}/auth/admin/realms/{realm}/clients/{id}')
+    '{server}/admin/realms/{realm}/clients/{id}')
 URL_CLIENT_SECRET = (
-    '{server}/auth/admin/realms/{realm}/clients/{id}/client-secret')
+    '{server}/admin/realms/{realm}/clients/{id}/client-secret')
 URL_CLIENT_DESCRIPTION_CONVERTER = (
-    '{server}/auth/admin/realms/{realm}/client-description-converter')
+    '{server}/admin/realms/{realm}/client-description-converter')
 
 URL_INITIAL_ACCESS_TOKEN = (
-    '{server}/auth/admin/realms/{realm}/clients-initial-access')
+    '{server}/admin/realms/{realm}/clients-initial-access')
 URL_CLIENT_REGISTRATION_DEFAULT = (
-    '{server}/auth/realms/{realm}/clients-registrations/default')
+    '{server}/realms/{realm}/clients-registrations/default')
 URL_CLIENT_REGISTRATION_SAML2 = (
-    '{server}/auth/realms/{realm}/clients-registrations/saml2-entity-descriptor')
+    '{server}/realms/{realm}/clients-registrations/saml2-entity-descriptor')
 URL_CLIENT_REGISTRATION_OIDC = (
-    '{server}/auth/realms/{realm}/clients-registrations/openid-connect')
+    '{server}/realms/{realm}/clients-registrations/openid-connect')
 
 URL_CLIENT_PROTOCOL_MAPPER_MODEL = (
-    '{server}/auth/admin/realms/{realm}/clients/{id}/protocol-mappers/models')
+    '{server}/admin/realms/{realm}/clients/{id}/protocol-mappers/models')
 
 
 CONTENT_TYPE_JSON = 'application/json;charset=utf-8'

--- a/keycloak_httpd_client/keycloak_rest.py
+++ b/keycloak_httpd_client/keycloak_rest.py
@@ -99,7 +99,7 @@ class RESTError(Exception):
 class KeycloakREST(object):
 
     def __init__(self, server, auth_role=None, session=None):
-        self.server = server
+        self.server = server.rstrip('/')
         self.auth_role = auth_role
         self.session = session
 

--- a/keycloak_httpd_client/utils.py
+++ b/keycloak_httpd_client/utils.py
@@ -13,6 +13,7 @@ import shutil
 import sys
 import subprocess
 import tempfile
+import requests
 
 import six
 from six.moves.urllib.parse import quote as urlquote
@@ -514,6 +515,19 @@ def normalize_url(url, default_scheme='https'):
         netloc = '%s:%d' % (hostname, port)
 
     return urlunsplit((scheme, netloc, path, query, fragment))
+
+def normalize_keycloak_server_url(url):
+    value = url.rstrip('/')
+    if value.count('/') > 3 or value.endswith('/auth'):
+        return value
+    try:
+        r = requests.get(value + '/auth', allow_redirects=False)
+        if r.status_code < 400:
+            return value + '/auth'
+        else:
+            return value
+    except Exception:
+        return value
 
 # ------------------------------ PEM Utilities --------------------------------
 

--- a/templates/oidc_httpd.conf
+++ b/templates/oidc_httpd.conf
@@ -1,5 +1,5 @@
 OIDCClientID {{ clientid }}
-OIDCProviderMetadataURL {{ keycloak_server_url }}/auth/realms/{{ keycloak_realm }}/.well-known/openid-configuration
+OIDCProviderMetadataURL {{ keycloak_server_url }}/realms/{{ keycloak_realm }}/.well-known/openid-configuration
 OIDCCryptoPassphrase {{ crypto_passphrase }}
 OIDCClientSecret {{ oidc_client_secret }}
 OIDCRedirectURI {{ client_https_url }}{{ oidc_redirect_uri }}


### PR DESCRIPTION
New keycloak (that uses quarkus) runs on web root.

 This PR removes /auth from the path. The keycloak_httpd_client
 can be still used with the old version, just the --server parameter
 must be complete URL (https://keycloak.example.com/auth)
